### PR TITLE
Fix access to riddle admin page by using provided permission

### DIFF
--- a/riddle_marketplace.routing.yml
+++ b/riddle_marketplace.routing.yml
@@ -3,7 +3,7 @@ riddle_marketplace.list:
   defaults:
     _controller: '\Drupal\riddle_marketplace\Controller\RiddleController::riddleIframe'
   requirements:
-    _permission: 'access content'
+    _permission: 'generate riddle_marketplace'
 
 riddle_marketplace.admin_settings:
   path: '/admin/config/content/riddle_marketplace'


### PR DESCRIPTION
Users with permission to access content can also access the admin page of the riddle module where editors can manage riddles.

Not only riddles but also detailled information about the subscription is accessible and editable.

This PR fixes this security issue by using the provided permission of the module to access this page. 